### PR TITLE
Escape path to allow copying into paths with spaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "refmterr dune build -p #{self.name}",
     "install": [
       "esy-installer reason-font-manager.install",
-      "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll $cur__bin': 'echo no-op'}\""
+      "bash -c \"#{os == 'windows' ? 'cp /usr/x86_64-w64-mingw32/sys-root/mingw/bin/*.dll \\'$cur__bin\\'': 'echo no-op'}\""
     ],
     "buildsInSource": "_build"
   },


### PR DESCRIPTION
This and the associated `revery` fix meant I could run `oni2` locally again on Windows, with my awkward path with spaces. I also had to apply the same fix in `oni2`.

Is there any way to avoid this issue entirely...perhaps an upstream `esy` change to avoid this in the first place? Especially when the quoting makes it a pain to do any of this, and even worse when the commands are then put into more quotes later.